### PR TITLE
chore(ci): use stable rockcraft

### DIFF
--- a/.github/workflows/build-rock.yaml
+++ b/.github/workflows/build-rock.yaml
@@ -17,8 +17,6 @@ jobs:
 
       - name: Build rock
         uses: canonical/craft-actions/rockcraft-pack@main
-        with:
-          rockcraft-channel: candidate
 
       - name: Get rock name
         id: vars


### PR DESCRIPTION
Now that Rockcraft 1.1.0 is in the stable channel we can rely on it for the "entrypoint-service" support.