### PR TITLE
feat: bundle the base snap

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -52,6 +52,25 @@ parts:
       # This is where Snapcraft projects on the host should be mounted
       mkdir -p ${CRAFT_PART_INSTALL}/project
 
+  base-snap:
+    plugin: nil
+    stage-snaps:
+      - core22 # Update all instances of this to the desired target base
+    override-build: |
+      # usrmerge symlinks exist in the base snap, so create the ones we need here
+      # because 'organize' does not like directory symlinks
+      mkdir -p ${CRAFT_PART_INSTALL}/snap/core22/current
+      ln -s usr/lib ${CRAFT_PART_INSTALL}/snap/core22/current/lib
+      ln -s usr/lib64 ${CRAFT_PART_INSTALL}/snap/core22/current/lib64
+    organize:
+      # This is used by craft-parts to determine the cutoff for stage-packages
+      usr/share/snappy/dpkg.list: snap/core22/current/usr/share/snappy/dpkg.list
+      # These are for patchelf fixing and library linting
+      usr/lib/${CRAFT_ARCH_TRIPLET}: snap/core22/current/usr/lib/${CRAFT_ARCH_TRIPLET}
+      usr/lib64: snap/core22/current/usr/lib64
+    stage:
+      - snap/core22/current/*
+
   legacy-dirs:
     plugin: nil
     override-build: |

--- a/tests/spread/general/classic-patchelf/Makefile
+++ b/tests/spread/general/classic-patchelf/Makefile
@@ -1,0 +1,11 @@
+# -*- Mode: Makefile; indent-tabs-mode:t; tab-width: 4 -*-
+.PHONY: all
+
+all: hello-classic
+
+install: hello-classic
+	install -d $(DESTDIR)/bin/
+	install -D $^ $(DESTDIR)/bin/
+
+hello-classic: hello-classic.c
+	$(CC) hello-classic.c -o hello-classic -lcurl

--- a/tests/spread/general/classic-patchelf/hello-classic.c
+++ b/tests/spread/general/classic-patchelf/hello-classic.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+#include <curl/curl.h>
+
+int main() {
+    curl_global_init(CURL_GLOBAL_DEFAULT);
+}

--- a/tests/spread/general/classic-patchelf/snap/snapcraft.yaml
+++ b/tests/spread/general/classic-patchelf/snap/snapcraft.yaml
@@ -1,0 +1,19 @@
+name: patchelf
+version: "1.0"
+summary: test
+description: patchelf
+grade: devel
+confinement: classic
+base: SNAPCRAFT_BASE
+build-base: SNAPCRAFT_BUILD_BASE
+
+parts:
+  hello:
+    source: .
+    plugin: make
+    build-packages:
+      - gcc
+      - libc6-dev
+      - libcurl4-openssl-dev
+    build-attributes:
+      - enable-patchelf

--- a/tests/spread/general/classic-patchelf/task.yaml
+++ b/tests/spread/general/classic-patchelf/task.yaml
@@ -1,0 +1,18 @@
+summary: Check the building and linting of classic snaps
+
+execute: |
+  # pack the snap
+  run_snapcraft pack 2>&1 | tee output.txt
+
+  # Check that the rpath was fixed
+  expected_rpath="Proposed rpath=\['/snap/${SNAPCRAFT_BASE}/current/lib/x86_64-linux-gnu'\]"
+  MATCH "$expected_rpath" < output.txt
+
+  # Check that the linter is working (by declaring  that libcurl was not found)
+  expected_libcurl="library: bin/hello-classic: missing dependency 'libcurl"
+  MATCH "$expected_libcurl" < output.txt
+
+  # Check that libraries that are *not* packed on the snap but *are* present on
+  # the base snap are not listed as missing
+  unexpected_libresolv="library: bin/hello-classic: missing dependency 'libresolv.so"
+  NOMATCH "$unexpected_libresolv" < output.txt

--- a/tests/spread/general/package-cutoff/snap/snapcraft.yaml
+++ b/tests/spread/general/package-cutoff/snap/snapcraft.yaml
@@ -1,0 +1,25 @@
+# NOTE: This project comes from snapcraft
+# (tests/spread/core24/snap-creation/package-cutoff)
+name: package-cutoff
+base: SNAPCRAFT_BASE
+build-base: SNAPCRAFT_BUILD_BASE
+version: '1.0'
+summary: 'test'
+description: test
+grade: devel
+confinement: devmode
+
+# The parts defined here will be in conflict if the package-cutoff is not working;
+# Without the cutoff, part-1's staging of libpng16-16 will pull in libc6, which
+# will create a directory called "lib64/". part-2's python plugin will also create
+# "lib64", but as a symlink to "lib". The regular directory and the symlink will
+# then be in conflict and the build will fail.
+parts:
+  part-1:
+    source: .
+    plugin: nil
+    stage-packages:
+      - libpng16-16
+  part-2:
+    source: .
+    plugin: python

--- a/tests/spread/general/package-cutoff/task.yaml
+++ b/tests/spread/general/package-cutoff/task.yaml
@@ -1,0 +1,9 @@
+summary: Test package cutoff due to base snap
+
+
+execute: |
+  # pack the snap
+  run_snapcraft pack
+
+  # Make sure the packed snap does *not* have a bundled libc6
+  unsquashfs -l package-cutoff_1.0_amd64.snap | NOMATCH libc\.so


### PR DESCRIPTION
The base coreXX snap is needed for things like determining the package cutoff and classic linting/fixing.