### PR TITLE
fix: make dpkg/apt aware of installed python packages

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -20,9 +20,14 @@ parts:
     source-tag: ${CRAFT_PROJECT_VERSION}
     stage-packages:
       - python3-venv
+    overlay-packages:
+      # Note: this declaration seems redundant but it's here to ensure that the
+      # Apt installation inside the rock is aware that these Python packages
+      # (python3-venv and its dependencies) are already installed. Otherwise,
+      # installing them (as a build-package in a snapcraft.yaml) would clobber
+      # the sitecustomize.py added by rockcraft.
+      - python3-venv
     python-packages:
-      - wheel
-      - pip
       # Limited to < 66 because we need `pkg_resources` and because `python-apt`
       # does not build with the latest (shouldn't this be in constraints.txt?)
       - setuptools<66
@@ -37,6 +42,13 @@ parts:
       bin/snapcraftctl: bin/scriptlet-bin/snapcraftctl
       # Also install the compatibility wrapper for core22+.
       bin/snapcraftctl-compat: usr/libexec/snapcraft/snapcraftctl
+    stage:
+      # Explicitly filter out the pip installed in Snapcraft's virtual environment,
+      # because it can conflict with the Python installation in the rock and
+      # the virtual environments created by the 'python' plugin when executing
+      # Snapcraft.
+      - -bin/pip*
+      - -lib/python3.*/site-packages/pip*
 
   build-deps:
     plugin: nil

--- a/tests/spread/general/craftctl/snap/snapcraft.yaml
+++ b/tests/spread/general/craftctl/snap/snapcraft.yaml
@@ -11,14 +11,21 @@ build-base: SNAPCRAFT_BUILD_BASE
 parts:
   hello:
     plugin: nil
+    build-packages:
+      # Note: We add this package explicitly here to make sure that the
+      # declaration of Python build packages does not clobber the existing
+      # Python installation (with Snapcraft libraries).
+      - python3-venv
     override-pull: |
       echo -e "#!/usr/bin/env bash\necho hello" > hello.sh
       chmod +x hello.sh
       craftctl get grade | grep devel
       craftctl set version="22"
       craftctl set grade=stable
+      craftctl default
     override-build: |
       craftctl get version | grep 22
       craftctl get grade | grep stable
+      craftctl default
       echo "This is the build step"
       cp hello.sh "$CRAFT_PART_INSTALL"/


### PR DESCRIPTION
This fixes an issue where calling "craftctl" in a scriptlet would fail with a ModuleNotFoundError for craft_parts. This happened when the snapcraft project included build-packages that pulled in libpython3.10-minimal.

The reason that this failed is because in Rockcraft the `python` plugin (used to build the `snapcraft` part) works by adding a custom "sitecustomize.py" in `/usr/lib/python3.10/` to add the part's Python libraries to the Python path. This is fine unless the `libpython3.10-minimal` package is explicitly installed later on a container created from the rock, because that package has its own sitecustomize.py file which overwrites Rockcraft's.

The solution is to make apt and dpkg aware that all of these Python-related packages are already installed in the rock, by adding the dependency explicitly as an `overlay-package`. This also has the extra beneficial side-effect of improving installation of build-packages because dpkg/apt are aware of the installed packages and don't have to download and re-install them unnecessarily.

Fixes #33.