### PR TITLE
chore: update to snapcraft 8.9.2

### DIFF
--- a/.github/workflows/build-rock.yaml
+++ b/.github/workflows/build-rock.yaml
@@ -29,9 +29,7 @@ jobs:
           fi
 
       - name: Upload rock
-        # NOTE: using v3 (for this and other actions) due to node versions
-        # on self-hosted runners (no node20)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: snapcraft-rock
           path: '*.rock'
@@ -47,13 +45,13 @@ jobs:
           mkdir "${{ github.workspace }}"
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
 
       - name: Download rock artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: snapcraft-rock
           path: tests
@@ -70,7 +68,7 @@ jobs:
       packages: write
     steps:
       - name: Download rock artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: snapcraft-rock
 

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -10,6 +10,8 @@ description: |
   It solves the problems of dependency management and architecture support by bundling all of a software’s libraries into the container itself, and provides a way to package any app, program, toolkit, or library for all major Linux distributions and IoT devices.
 
   Snapcraft is for developers, package maintainers, fleet administrators, and hobbyists who are interested in publishing snaps for Linux and IoT devices.
+
+  This rock is intended for building snaps using the core24 base with Snapcraft 8.
 license: GPL-3.0
 platforms:
   amd64: #TODO

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,32 +1,40 @@
 name: snapcraft-core24
 base: ubuntu@24.04
-version: 8.4.1
-summary: easily create core24 snaps
+version: 8.9.2
+summary: Package, distribute, and update any app for Linux and IoT.
 description: |
-  Snapcraft aims to make upstream developers' lives easier and as such is not
-  a single toolset, but instead is a collection of tools that enable the
-  natural workflow of an upstream to be extended with a simple release step
-  into Snappy.
-  This version of Snapcraft is able to build core24 snaps in destructive mode
-  only.
+  Snapcraft is the command-line build tool for packaging and distributing software and apps in the snap container format.
+
+  The tool packages apps across many supported languages, build tools, and frameworks, such as Python, C and C++, Rust, Node, and GNOME. Snaps can be tested, debugged, and locally shared before being published to the global Snap Store and private stores. It uses simple commands to manage and monitor releases at a granular level.
+
+  It solves the problems of dependency management and architecture support by bundling all of a software’s libraries into the container itself, and provides a way to package any app, program, toolkit, or library for all major Linux distributions and IoT devices.
+
+  Snapcraft is for developers, package maintainers, fleet administrators, and hobbyists who are interested in publishing snaps for Linux and IoT devices.
 license: GPL-3.0
 platforms:
   amd64: #TODO
 
 parts:
   snapcraft:
+    # We can't use the uv plugin because it rewrites shebangs in scripts from the python3-venv package.
+    # For example, the uv plugin changes the shebang in `/usr/bin/dpkg-maintscript-helper` from dpkg
+    #  from `#! /bin/sh` to `#! /bin/python3`. This causes Snapcraft to fail when installing build packages.
     plugin: python
     source: https://github.com/snapcore/snapcraft.git
     source-tag: ${CRAFT_PROJECT_VERSION}
-    stage-packages:
-      - python3-venv
+    python-requirements:
+      - uv-requirements.txt
+      - requirements-noble.txt
     python-packages:
       - wheel
       - pip
-    python-constraints:
-      - constraints.txt
-    python-requirements:
-      - requirements.txt
+    stage-packages:
+      - python3-venv
+    build-snaps:
+      - astral-uv
+    override-build: |
+      uv export --no-dev --no-emit-workspace --output-file uv-requirements.txt
+      craftctl default
     organize:
       # Put snapcraftctl and craftctl into its own directory that can be included in the PATH
       # without including other binaries.
@@ -53,7 +61,7 @@ parts:
   base-snap:
     plugin: nil
     stage-snaps:
-      - core24/latest/edge # Must use edge while core24 is not released
+      - core24
     override-build: |
       # usrmerge symlinks exist in the base snap, so create the ones we need here
       # because 'organize' does not like directory symlinks

--- a/tests/spread/general/architectures/snap/snapcraft.yaml
+++ b/tests/spread/general/architectures/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: architectures
 grade: devel
 confinement: strict
 base: SNAPCRAFT_BASE
-build-base: SNAPCRAFT_BUILD_BASE
 
 platforms:
   amd64:

--- a/tests/spread/general/classic-patchelf/snap/snapcraft.yaml
+++ b/tests/spread/general/classic-patchelf/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: patchelf
 grade: devel
 confinement: classic
 base: SNAPCRAFT_BASE
-build-base: SNAPCRAFT_BUILD_BASE
 
 parts:
   hello:

--- a/tests/spread/general/craftctl/snap/snapcraft.yaml
+++ b/tests/spread/general/craftctl/snap/snapcraft.yaml
@@ -6,7 +6,6 @@ grade: devel
 confinement: strict
 adopt-info: hello
 base: SNAPCRAFT_BASE
-build-base: SNAPCRAFT_BUILD_BASE
 
 parts:
   hello:

--- a/tests/spread/general/features/build-packages/snap/snapcraft.yaml
+++ b/tests/spread/general/features/build-packages/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: Check that build-packages work
 grade: devel
 confinement: strict
 base: SNAPCRAFT_BASE
-build-base: SNAPCRAFT_BUILD_BASE
 
 parts:
   hello-world:

--- a/tests/spread/general/features/package-repositories/snap/snapcraft.yaml
+++ b/tests/spread/general/features/package-repositories/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: package-repositories
 grade: devel
 confinement: strict
 base: SNAPCRAFT_BASE
-build-base: SNAPCRAFT_BUILD_BASE
 
 parts:
   test-ppa:

--- a/tests/spread/general/features/patchelf/snap/snapcraft.yaml
+++ b/tests/spread/general/features/patchelf/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: patchelf
 grade: devel
 confinement: strict
 base: SNAPCRAFT_BASE
-build-base: SNAPCRAFT_BUILD_BASE
 
 parts:
   hello:

--- a/tests/spread/general/hello/snap/snapcraft.yaml
+++ b/tests/spread/general/hello/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: hello-world
 grade: devel
 confinement: strict
 base: SNAPCRAFT_BASE
-build-base: SNAPCRAFT_BUILD_BASE
 
 parts:
   hello-world:

--- a/tests/spread/general/package-cutoff/snap/snapcraft.yaml
+++ b/tests/spread/general/package-cutoff/snap/snapcraft.yaml
@@ -2,7 +2,6 @@
 # (tests/spread/core24/snap-creation/package-cutoff)
 name: package-cutoff
 base: SNAPCRAFT_BASE
-build-base: SNAPCRAFT_BUILD_BASE
 version: '1.0'
 summary: 'test'
 description: test

--- a/tests/spread/snapcraft-8/chisel/snap/snapcraft.yaml
+++ b/tests/spread/snapcraft-8/chisel/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: chisel
 grade: devel
 confinement: strict
 base: SNAPCRAFT_BASE
-build-base: SNAPCRAFT_BUILD_BASE
 
 parts:
   base:


### PR DESCRIPTION
Updates the core24-8 rock to Snapcraft 8.9.2.

There were a few changes:
- Snapcraft switched to the uv plugin.
- Github actions were outdated.
- The edge channel for `core24` was being used.
- `build-base` was defined in the spread tests, which is only needed when it is different than `base`.

Once this PR is approved, I'll open PRs for the other branches (core22-8, core22-7).

Fixes #65
(SNAPCRAFT-1133)