### PR TITLE
fix: make dpkg/apt aware of installed python packages

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -18,9 +18,7 @@ platforms:
 
 parts:
   snapcraft:
-    # We can't use the uv plugin because it rewrites shebangs in scripts from the python3-venv package.
-    # For example, the uv plugin changes the shebang in `/usr/bin/dpkg-maintscript-helper` from dpkg
-    #  from `#! /bin/sh` to `#! /bin/python3`. This causes Snapcraft to fail when installing build packages.
+    # The uv plugin can't be used until https://github.com/canonical/rockcraft/issues/889 is resolved.
     plugin: python
     source: https://github.com/snapcore/snapcraft.git
     source-tag: ${CRAFT_PROJECT_VERSION}

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -36,6 +36,10 @@ parts:
       # installing them (as a build-package in a snapcraft.yaml) would clobber
       # the sitecustomize.py added by rockcraft.
       - python3-venv
+    overlay:
+      # Remove the sitecustomize added by python3-venv's dependencies, because
+      # we want to use the one provided by the python plugin.
+      - -usr/lib/python3.12/sitecustomize.py
     build-snaps:
       - astral-uv
     override-build: |
@@ -129,10 +133,6 @@ parts:
       - bin/patchelf
 
   chisel:
-    # This must be after the 'snapcraft' part. Otherwise, `usr/lib/python3.12/sitecustomize.py`
-    # created by the Python plugin from the 'snapcraft' part never gets staged.
-    after:
-      - snapcraft
     plugin: nil
     stage-snaps:
       - chisel/latest/candidate

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -27,10 +27,14 @@ parts:
     python-requirements:
       - uv-requirements.txt
       - requirements-noble.txt
-    python-packages:
-      - wheel
-      - pip
     stage-packages:
+      - python3-venv
+    overlay-packages:
+      # Note: this declaration seems redundant but it's here to ensure that the
+      # Apt installation inside the rock is aware that these Python packages
+      # (python3-venv and its dependencies) are already installed. Otherwise,
+      # installing them (as a build-package in a snapcraft.yaml) would clobber
+      # the sitecustomize.py added by rockcraft.
       - python3-venv
     build-snaps:
       - astral-uv
@@ -44,6 +48,13 @@ parts:
       bin/snapcraftctl: bin/scriptlet-bin/snapcraftctl
       # Also install the compatibility wrapper for core22+.
       bin/snapcraftctl-compat: usr/libexec/snapcraft/snapcraftctl
+    stage:
+      # Explicitly filter out the pip installed in Snapcraft's virtual environment,
+      # because it can conflict with the Python installation in the rock and
+      # the virtual environments created by the 'python' plugin when executing
+      # Snapcraft.
+      - -bin/pip*
+      - -lib/python3.*/site-packages/pip*
 
   build-deps:
     plugin: nil

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -129,6 +129,10 @@ parts:
       - bin/patchelf
 
   chisel:
+    # This must be after the 'snapcraft' part. Otherwise, `usr/lib/python3.12/sitecustomize.py`
+    # created by the Python plugin from the 'snapcraft' part never gets staged.
+    after:
+      - snapcraft
     plugin: nil
     stage-snaps:
       - chisel/latest/candidate

--- a/tests/spread/general/craftctl/snap/snapcraft.yaml
+++ b/tests/spread/general/craftctl/snap/snapcraft.yaml
@@ -10,6 +10,11 @@ base: SNAPCRAFT_BASE
 parts:
   hello:
     plugin: nil
+    build-packages:
+      # Note: We add this package explicitly here to make sure that the
+      # declaration of Python build packages does not clobber the existing
+      # Python installation (with Snapcraft libraries).
+      - python3-venv
     override-pull: |
       echo -e "#!/usr/bin/env bash\necho hello" > hello.sh
       chmod +x hello.sh
@@ -17,7 +22,9 @@ parts:
       # with 'devel' build-base can only have 'devel' grade. We can update
       # this when core24 is stable.
       craftctl set version="22"
+      craftctl default
     override-build: |
       craftctl get version | grep 22
       echo "This is the build step"
       cp hello.sh "$CRAFT_PART_INSTALL"/
+      craftctl default


### PR DESCRIPTION
Cherry-picks #45 and changes the order of parts to prevent `sitecustomize.py` from getting overwritten.