### PR TITLE
chore: update to snapcraft 8.9.2 (core22-8)

### DIFF
--- a/.github/workflows/build-rock.yaml
+++ b/.github/workflows/build-rock.yaml
@@ -29,9 +29,7 @@ jobs:
           fi
 
       - name: Upload rock
-        # NOTE: using v3 (for this and other actions) due to node versions
-        # on self-hosted runners (no node20)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: snapcraft-rock
           path: '*.rock'
@@ -47,13 +45,13 @@ jobs:
           mkdir "${{ github.workspace }}"
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
 
       - name: Download rock artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: snapcraft-rock
           path: tests
@@ -70,7 +68,7 @@ jobs:
       packages: write
     steps:
       - name: Download rock artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: snapcraft-rock
 

--- a/.github/workflows/build-rock.yaml
+++ b/.github/workflows/build-rock.yaml
@@ -10,7 +10,11 @@ on:
 
 jobs:
   build-rock:
-    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        runner: [self-hosted]
+        arch: [amd64, arm64]
+    runs-on: ["${{ matrix.runner }}", "${{ matrix.arch }}"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -31,7 +35,7 @@ jobs:
       - name: Upload rock
         uses: actions/upload-artifact@v4
         with:
-          name: snapcraft-rock
+          name: snapcraft-${{ matrix.arch }}-rock
           path: '*.rock'
 
   spread-tests:
@@ -53,14 +57,14 @@ jobs:
       - name: Download rock artifact
         uses: actions/download-artifact@v4
         with:
-          name: snapcraft-rock
+          name: snapcraft-amd64-rock
           path: tests
 
       - name: Run spread
         run: spread
 
   publish-rock:
-    runs-on: ubuntu-22.04
+    runs-on: self-hosted
     needs: [build-rock]
     # Not on pull requests; only when they're merged
     if: github.event_name == 'push'
@@ -70,7 +74,7 @@ jobs:
       - name: Download rock artifact
         uses: actions/download-artifact@v4
         with:
-          name: snapcraft-rock
+          name: snapcraft-amd64-rock
 
       - name: Install rockcraft
         run: sudo snap install --classic rockcraft
@@ -86,5 +90,5 @@ jobs:
           target_image="ghcr.io/canonical/snapcraft:${snapcraft_version}_${snapcraft_core}"
           dest_image="docker://${target_image}"
 
-          /snap/rockcraft/current/bin/skopeo --insecure-policy copy ${source_rock} ${dest_image} --dest-creds "${{ github.repository_owner }}:${{ secrets.GITHUB_TOKEN }}"
+          rockcraft.skopeo --insecure-policy copy ${source_rock} ${dest_image} --dest-creds "${{ github.repository_owner }}:${{ secrets.GITHUB_TOKEN }}"
           echo "Image is available at ${target_image}"

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -14,7 +14,8 @@ description: |
   This rock is intended for building snaps using the core22 base with Snapcraft 8 in destructive mode.
 license: GPL-3.0
 platforms:
-  amd64: #TODO
+  amd64:
+  arm64:
 
 package-repositories:
   - type: apt

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -20,9 +20,14 @@ parts:
     source-tag: ${CRAFT_PROJECT_VERSION}
     stage-packages:
       - python3-venv
+    overlay-packages:
+      # Note: this declaration seems redundant but it's here to ensure that the
+      # Apt installation inside the rock is aware that these Python packages
+      # (python3-venv and its dependencies) are already installed. Otherwise,
+      # installing them (as a build-package in a snapcraft.yaml) would clobber
+      # the sitecustomize.py added by rockcraft.
+      - python3-venv
     python-packages:
-      - wheel
-      - pip
       # Limited to < 66 because we need `pkg_resources` and because `python-apt`
       # does not build with the latest (shouldn't this be in constraints.txt?)
       - setuptools<66
@@ -37,6 +42,13 @@ parts:
       bin/snapcraftctl: bin/scriptlet-bin/snapcraftctl
       # Also install the compatibility wrapper for core22+.
       bin/snapcraftctl-compat: usr/libexec/snapcraft/snapcraftctl
+    stage:
+      # Explicitly filter out the pip installed in Snapcraft's virtual environment,
+      # because it can conflict with the Python installation in the rock and
+      # the virtual environments created by the 'python' plugin when executing
+      # Snapcraft.
+      - -bin/pip*
+      - -lib/python3.*/site-packages/pip*
 
   build-deps:
     plugin: nil

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,40 +1,60 @@
 name: snapcraft-core22
 base: ubuntu@22.04
-version: 8.2.10
-summary: easily create core22 snaps
+version: 8.9.2
+summary: Package, distribute, and update any app for Linux and IoT.
 description: |
-  Snapcraft aims to make upstream developers' lives easier and as such is not
-  a single toolset, but instead is a collection of tools that enable the
-  natural workflow of an upstream to be extended with a simple release step
-  into Snappy.
-  This version of Snapcraft is able to build core22 snaps in destructive mode
-  only.
+  Snapcraft is the command-line build tool for packaging and distributing software and apps in the snap container format.
+
+  The tool packages apps across many supported languages, build tools, and frameworks, such as Python, C and C++, Rust, Node, and GNOME. Snaps can be tested, debugged, and locally shared before being published to the global Snap Store and private stores. It uses simple commands to manage and monitor releases at a granular level.
+
+  It solves the problems of dependency management and architecture support by bundling all of a software’s libraries into the container itself, and provides a way to package any app, program, toolkit, or library for all major Linux distributions and IoT devices.
+
+  Snapcraft is for developers, package maintainers, fleet administrators, and hobbyists who are interested in publishing snaps for Linux and IoT devices.
+
+  This rock is intended for building snaps using the core22 base with Snapcraft 8 in destructive mode.
 license: GPL-3.0
 platforms:
   amd64: #TODO
 
+package-repositories:
+  - type: apt
+    ppa: deadsnakes/ppa
+    priority: always
+
 parts:
   snapcraft:
+    # The uv plugin can't be used because Snapcraft calls apt, which will fail.
+    # See https://github.com/canonical/rockcraft/issues/889
     plugin: python
     source: https://github.com/snapcore/snapcraft.git
     source-tag: ${CRAFT_PROJECT_VERSION}
+    build-snaps:
+      - astral-uv
+    build-environment:
+      - PARTS_PYTHON_INTERPRETER: python3.12
     stage-packages:
-      - python3-venv
+      - python3.12-venv
     overlay-packages:
       # Note: this declaration seems redundant but it's here to ensure that the
       # Apt installation inside the rock is aware that these Python packages
       # (python3-venv and its dependencies) are already installed. Otherwise,
       # installing them (as a build-package in a snapcraft.yaml) would clobber
       # the sitecustomize.py added by rockcraft.
-      - python3-venv
-    python-packages:
-      # Limited to < 66 because we need `pkg_resources` and because `python-apt`
-      # does not build with the latest (shouldn't this be in constraints.txt?)
-      - setuptools<66
-    python-constraints:
-      - constraints.txt
+      - python3.12-venv
+    overlay:
+      # Remove the sitecustomize added by python3-venv's dependencies, because
+      # we want to use the one provided by the python plugin.
+      - -usr/lib/python3.12/sitecustomize.py
     python-requirements:
-      - requirements.txt
+      - uv-requirements.txt
+      - requirements-jammy.txt
+    override-pull: |
+      craftctl default
+      echo "python-apt @ https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.4.0ubuntu4/python-apt_2.4.0ubuntu4.tar.xz \
+      --hash=sha256:4ab9c915d1295afbf2ca197993454d3659bb8dee4e9cd39ceba9efe5970873cc" > requirements-jammy.txt
+    override-build: |
+      uv export --no-dev --no-emit-workspace --output-file uv-requirements.txt
+      craftctl default
     organize:
       # Put snapcraftctl and craftctl into its own directory that can be included in the PATH
       # without including other binaries.
@@ -54,6 +74,7 @@ parts:
     plugin: nil
     build-packages:
       - libapt-pkg-dev
+      - python3.12-dev
 
   run-deps:
     plugin: nil
@@ -134,6 +155,9 @@ parts:
       - usr/libexec/snapcraft/chisel
 
 entrypoint-service: snapcraft
+
+environment:
+  PEBBLE_VERBOSE: 1
 
 services:
   snapcraft:

--- a/spread.yaml
+++ b/spread.yaml
@@ -67,6 +67,9 @@ prepare: |
     # Latest docker snap needs a more recent version of snapd than Fedora ships
     # https://github.com/canonical/rockcraft/pull/277
     snap install docker --channel=core18/stable
+  elif [[ "$SPREAD_SYSTEM" =~ ubuntu-22.04 ]]; then
+    # https://github.com/canonical/docker-snap/issues/281
+    apt install -y docker.io
   else
     snap install docker
   fi

--- a/tests/spread/general/architectures/snap/snapcraft.yaml
+++ b/tests/spread/general/architectures/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: architectures
 grade: devel
 confinement: strict
 base: SNAPCRAFT_BASE
-build-base: SNAPCRAFT_BUILD_BASE
 
 architectures:
   - build-on: amd64

--- a/tests/spread/general/classic-patchelf/snap/snapcraft.yaml
+++ b/tests/spread/general/classic-patchelf/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: patchelf
 grade: devel
 confinement: classic
 base: SNAPCRAFT_BASE
-build-base: SNAPCRAFT_BUILD_BASE
 
 parts:
   hello:

--- a/tests/spread/general/craftctl/snap/snapcraft.yaml
+++ b/tests/spread/general/craftctl/snap/snapcraft.yaml
@@ -11,14 +11,21 @@ build-base: SNAPCRAFT_BUILD_BASE
 parts:
   hello:
     plugin: nil
+    build-packages:
+      # Note: We add this package explicitly here to make sure that the
+      # declaration of Python build packages does not clobber the existing
+      # Python installation (with Snapcraft libraries).
+      - python3-venv
     override-pull: |
       echo -e "#!/usr/bin/env bash\necho hello" > hello.sh
       chmod +x hello.sh
       craftctl get grade | grep devel
       craftctl set version="22"
       craftctl set grade=stable
+      craftctl default
     override-build: |
       craftctl get version | grep 22
       craftctl get grade | grep stable
+      craftctl default
       echo "This is the build step"
       cp hello.sh "$CRAFT_PART_INSTALL"/

--- a/tests/spread/general/craftctl/snap/snapcraft.yaml
+++ b/tests/spread/general/craftctl/snap/snapcraft.yaml
@@ -6,7 +6,6 @@ grade: devel
 confinement: strict
 adopt-info: hello
 base: SNAPCRAFT_BASE
-build-base: SNAPCRAFT_BUILD_BASE
 
 parts:
   hello:

--- a/tests/spread/general/features/build-packages/snap/snapcraft.yaml
+++ b/tests/spread/general/features/build-packages/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: Check that build-packages work
 grade: devel
 confinement: strict
 base: SNAPCRAFT_BASE
-build-base: SNAPCRAFT_BUILD_BASE
 
 parts:
   hello-world:

--- a/tests/spread/general/features/package-repositories/snap/snapcraft.yaml
+++ b/tests/spread/general/features/package-repositories/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: package-repositories
 grade: devel
 confinement: strict
 base: SNAPCRAFT_BASE
-build-base: SNAPCRAFT_BUILD_BASE
 
 parts:
   test-ppa:

--- a/tests/spread/general/features/patchelf/snap/snapcraft.yaml
+++ b/tests/spread/general/features/patchelf/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: patchelf
 grade: devel
 confinement: strict
 base: SNAPCRAFT_BASE
-build-base: SNAPCRAFT_BUILD_BASE
 
 parts:
   hello:

--- a/tests/spread/general/hello/snap/snapcraft.yaml
+++ b/tests/spread/general/hello/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: hello-world
 grade: devel
 confinement: strict
 base: SNAPCRAFT_BASE
-build-base: SNAPCRAFT_BUILD_BASE
 
 parts:
   hello-world:

--- a/tests/spread/general/package-cutoff/snap/snapcraft.yaml
+++ b/tests/spread/general/package-cutoff/snap/snapcraft.yaml
@@ -2,7 +2,6 @@
 # (tests/spread/core24/snap-creation/package-cutoff)
 name: package-cutoff
 base: SNAPCRAFT_BASE
-build-base: SNAPCRAFT_BUILD_BASE
 version: '1.0'
 summary: 'test'
 description: test

--- a/tests/spread/snapcraft-8/chisel/snap/snapcraft.yaml
+++ b/tests/spread/snapcraft-8/chisel/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: chisel
 grade: devel
 confinement: strict
 base: SNAPCRAFT_BASE
-build-base: SNAPCRAFT_BUILD_BASE
 
 parts:
   base:


### PR DESCRIPTION
Updates the core22-8 rock to snapcraft 8.9.2, which includes:
- the dpkg fix from core22-7:
  - #45
- improvements and fixes from core24-8:
  - #66
  - #67
- enables arm64 builds
- updates to python 3.12, which is the minimum version needed for snapcraft

~~Blocked by https://github.com/canonical/snapcraft/issues/5522~~
Supersedes #46
Fixes #65
(SNAPCRAFT-1133)
(SNAPCRAFT-1141)