### PR TITLE
chore: show snapcraft output

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -144,6 +144,9 @@ parts:
 
 entrypoint-service: snapcraft
 
+environment:
+  PEBBLE_VERBOSE: 1
+
 services:
   snapcraft:
     override: replace

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -11,7 +11,7 @@ description: |
 
   Snapcraft is for developers, package maintainers, fleet administrators, and hobbyists who are interested in publishing snaps for Linux and IoT devices.
 
-  This rock is intended for building snaps using the core24 base with Snapcraft 8.
+  This rock is intended for building snaps using the core24 base with Snapcraft 8 in destructive mode.
 license: GPL-3.0
 platforms:
   amd64: #TODO

--- a/spread.yaml
+++ b/spread.yaml
@@ -86,6 +86,7 @@ prepare: |
 restore-each: |
   # Cleanup after each task.
   rm -f ./*.snap
+  rm -rf ./parts ./stage ./prime
 
 
 suites:

--- a/tools/spread/run_snapcraft
+++ b/tools/spread/run_snapcraft
@@ -5,5 +5,4 @@
 # replace the SNAPCRAFT_* tokens with the correct values for our Snapcraft image
 sed --in-place='' "s/SNAPCRAFT_BASE/$SNAPCRAFT_BASE/" snap/snapcraft.yaml
 sed --in-place='' "s/SNAPCRAFT_BUILD_BASE/$SNAPCRAFT_BUILD_BASE/" snap/snapcraft.yaml
-# in ubuntu@24.04 rocks pebble is not verbose by default
-docker run --rm -v `pwd`:/project --entrypoint="/usr/bin/pebble" snapcraft-rock:latest enter --verbose --args snapcraft "$@"
+docker run --rm -v `pwd`:/project snapcraft-rock:latest "$@"


### PR DESCRIPTION
[Pebble 1.13](https://github.com/canonical/pebble/releases/tag/v1.13.0) disabled verbose output and recently, [Pebble 1.20](https://github.com/canonical/pebble/releases/tag/v1.20.0) added a new environment variable called `PEBBLE_VERBOSE`.

The reason we want verbose output is to see the output of snapcraft. Without it, you don't see any output from snapcraft.

We know that this is working, otherwise [`tests/spread/general/classic-patchelf`](https://github.com/canonical/snapcraft-rocks/blob/3725e172b4fe047fce11d4c9c5a4443fd7cd48ef/tests/spread/general/classic-patchelf/task.yaml#L6) won't be able to parse the output.