### PR TITLE
chore: update to snapcraft 7.5.8

### DIFF
--- a/.github/workflows/build-rock.yaml
+++ b/.github/workflows/build-rock.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Upload rock
         # NOTE: using v3 (for this and other actions) due to node versions
         # on self-hosted runners (no node20)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: snapcraft-rock
           path: '*.rock'
@@ -47,13 +47,13 @@ jobs:
           mkdir "${{ github.workspace }}"
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
 
       - name: Download rock artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: snapcraft-rock
           path: tests
@@ -70,7 +70,7 @@ jobs:
       packages: write
     steps:
       - name: Download rock artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: snapcraft-rock
 

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,14 +1,17 @@
 name: snapcraft-core22
 base: ubuntu@22.04
-version: 7.5.5
-summary: easily create core22 snaps
+version: 7.5.8
+summary: Package, distribute, and update any app for Linux and IoT.
 description: |
-  Snapcraft aims to make upstream developers' lives easier and as such is not
-  a single toolset, but instead is a collection of tools that enable the
-  natural workflow of an upstream to be extended with a simple release step
-  into Snappy.
-  This version of Snapcraft is able to build core22 snaps in destructive mode
-  only.
+  Snapcraft is the command-line build tool for packaging and distributing software and apps in the snap container format.
+
+  The tool packages apps across many supported languages, build tools, and frameworks, such as Python, C and C++, Rust, Node, and GNOME. Snaps can be tested, debugged, and locally shared before being published to the global Snap Store and private stores. It uses simple commands to manage and monitor releases at a granular level.
+
+  It solves the problems of dependency management and architecture support by bundling all of a software’s libraries into the container itself, and provides a way to package any app, program, toolkit, or library for all major Linux distributions and IoT devices.
+
+  Snapcraft is for developers, package maintainers, fleet administrators, and hobbyists who are interested in publishing snaps for Linux and IoT devices.
+
+  This rock is intended for building snaps using the core22 base with Snapcraft 7 in destructive mode.
 license: GPL-3.0
 platforms:
   amd64: #TODO
@@ -122,6 +125,9 @@ parts:
       - bin/patchelf
 
 entrypoint-service: snapcraft
+
+environment:
+  PEBBLE_VERBOSE: 1
 
 services:
   snapcraft:

--- a/spread.yaml
+++ b/spread.yaml
@@ -83,6 +83,7 @@ prepare: |
 restore-each: |
   # Cleanup after each task.
   rm -f ./*.snap
+  rm -rf ./parts ./stage ./prime
 
 
 suites:


### PR DESCRIPTION
Updates the core22-7 rock to Snapcraft 7.5.8, bringing in minor fixes from the core24-7 and core24-8 branches, including the verbosity fix described in #69.

Supersedes #54
Fixes #65
(SNAPCRAFT-1133)