### PR TITLE
fix(core24-8/spread): use apt to install docker on focal

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -67,7 +67,7 @@ prepare: |
     # Latest docker snap needs a more recent version of snapd than Fedora ships
     # https://github.com/canonical/rockcraft/pull/277
     snap install docker --channel=core18/stable
-  elif [[ "$SPREAD_SYSTEM" =~ ubuntu-22.04 ]]; then
+  elif [[ "$SPREAD_SYSTEM" =~ ubuntu-2[02].04 ]]; then
     # https://github.com/canonical/docker-snap/issues/281
     apt install -y docker.io
   else


### PR DESCRIPTION
This fixes the Ubuntu 20.04 spread tests for the core24 snapcraft 8 rock.