### PR TITLE
ci(core22-8): don't use a spread runner for publishing the rock

### DIFF
--- a/.github/workflows/build-rock.yaml
+++ b/.github/workflows/build-rock.yaml
@@ -64,7 +64,7 @@ jobs:
         run: spread
 
   publish-rock:
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, amd64]
     needs: [build-rock]
     # Not on pull requests; only when they're merged
     if: github.event_name == 'push'


### PR DESCRIPTION
Resource contention could cause us to try to publish on the spread runner. This has us use the `amd64` runner label so we don't do so.

I tricked the fourth run of [this job](https://github.com/canonical/snapcraft-rocks/actions/runs/15621518381/job/44009148202) by loading up the spread runner :-)