### PR TITLE
test: cleanup test now that we have a new enough snapcraft

### DIFF
--- a/tests/spread/general/package-cutoff/snap/snapcraft.yaml
+++ b/tests/spread/general/package-cutoff/snap/snapcraft.yaml
@@ -22,9 +22,3 @@ parts:
   part-2:
     source: .
     plugin: python
-    stage-packages:
-      # TODO: we can remove this once Snapcraft is released with #4666
-      - libpython3.12-minimal
-      - libpython3.12-stdlib
-      - python3.12-minimal
-      - python3.12-venv


### PR DESCRIPTION
https://github.com/canonical/snapcraft/pull/4666 is stable and we're upgraded past that version so we can fix this test.