### PR TITLE
fix(test): fix spread tests on Fedora

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -63,11 +63,7 @@ prepare: |
       journalctl -xe
   fi
 
-  if [ "$SPREAD_SYSTEM" = "fedora-39-64" ]; then
-    # Latest docker snap needs a more recent version of snapd than Fedora ships
-    # https://github.com/canonical/rockcraft/pull/277
-    snap install docker --channel=core18/stable
-  elif [[ "$SPREAD_SYSTEM" =~ ubuntu-2[02].04 ]]; then
+  if [[ "$SPREAD_SYSTEM" =~ ubuntu-2[02].04 ]]; then
     # https://github.com/canonical/docker-snap/issues/281
     apt install -y docker.io
   else


### PR DESCRIPTION
The core18 docker branch has been closed, but Fedora 39 can work with the default docker branch.