### PR TITLE
chore: update snapcraft to 8.14.5 and build pygit2 1.18

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -18,8 +18,8 @@ platforms:
   arm64:
 
 parts:
-  # pygit2 >=1.18 requires libgit2 >=1.5 to build from source.
-  # Ubuntu 24.04 only ships 1.5.x, so we build the required version ourselves.
+  # pygit2 1.18 requires exactly libgit2 1.9.x to compile.
+  # Ubuntu 24.04 ships 1.7.2, so we build the required version ourselves.
   libgit2:
     source: https://github.com/libgit2/libgit2/archive/refs/tags/v1.9.1.tar.gz
     source-checksum: sha256/14cab3014b2b7ad75970ff4548e83615f74d719afe00aa479b4a889c1e13fc00

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,6 +1,6 @@
 name: snapcraft-core24
 base: ubuntu@24.04
-version: 8.11.1
+version: 8.14.5
 summary: Package, distribute, and update any app for Linux and IoT.
 description: |
   Snapcraft is the command-line build tool for packaging and distributing software and apps in the snap container format.

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -18,6 +18,24 @@ platforms:
   arm64:
 
 parts:
+  # pygit2 >=1.18 requires libgit2 >=1.5 to build from source.
+  # Ubuntu 24.04 only ships 1.5.x, so we build the required version ourselves.
+  libgit2:
+    source: https://github.com/libgit2/libgit2/archive/refs/tags/v1.9.1.tar.gz
+    source-checksum: sha256/14cab3014b2b7ad75970ff4548e83615f74d719afe00aa479b4a889c1e13fc00
+    plugin: cmake
+    cmake-parameters:
+      - -DCMAKE_INSTALL_PREFIX=/usr
+      - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      - -DBUILD_TESTS=OFF
+    build-attributes:
+      - enable-patchelf
+    build-packages:
+      - cmake
+      - gcc
+    prime:
+      - -usr/include
+
   snapcraft:
     # The uv plugin can't be used until https://github.com/canonical/rockcraft/issues/889 is resolved.
     plugin: python


### PR DESCRIPTION
pygit2 >=1.18 requires libgit2 1.9.x to compile its C extensions.
Ubuntu 24.04 only ships libgit2 1.7, so we build libgit2 1.9.1
from source, matching the approach used in the snapcraft snap.