### PR TITLE
ci: always discard spread workers in build-rock tests (core24-8)

### DIFF
--- a/.github/workflows/build-rock.yaml
+++ b/.github/workflows/build-rock.yaml
@@ -63,6 +63,14 @@ jobs:
       - name: Run spread
         run: spread
 
+      - name: Discard spread workers
+        if: always()
+        run: |
+          shopt -s nullglob
+          for r in .spread-reuse.*.yaml; do
+            spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')"
+          done
+
   publish-rock:
     runs-on: [self-hosted, amd64]
     needs: [build-rock]


### PR DESCRIPTION
This PR adds the 'Discard spread workers' cleanup step to the 'spread-tests' job in the 'build-rock.yaml' workflow.

Without this step, if the job is cancelled or crashes, the remote Google Cloud VM instances allocated by 'spread' are leaked and remain active until the halt timeout (2h).

SNAPCRAFT-1368